### PR TITLE
chore: peerDepedencies -> depedencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-mycs",
-  "version": "0.0.0-development",
+  "version": "1.0.1",
   "license": "MIT",
   "description": "Eslint config to use over all mycs projects",
   "main": "index.js",
@@ -22,7 +22,7 @@
     "eslint-config-mycs",
     "eslintconfig"
   ],
-  "peerDependencies": {
+  "dependencies": {
     "babel-eslint": "^7.1.1",
     "eslint": ">=3.12.2",
     "eslint-config-airbnb-base": "^11.0.0",


### PR DESCRIPTION
peerDependencies are not installed if missing (from 3.0 npm)